### PR TITLE
Remove Common from Mvp.Xml namespaces

### DIFF
--- a/src/Mvp.Xml.Tests/Common/EmptyXPathNodeIteratorTests.cs
+++ b/src/Mvp.Xml.Tests/Common/EmptyXPathNodeIteratorTests.cs
@@ -1,4 +1,4 @@
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/IndexingXPathNavigatorTest.cs
+++ b/src/Mvp.Xml.Tests/Common/IndexingXPathNavigatorTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/SingletonXPathNodeIteratorTests.cs
+++ b/src/Mvp.Xml.Tests/Common/SingletonXPathNodeIteratorTests.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/SubtreeeXPathNavigatorTests/Tests.cs
+++ b/src/Mvp.Xml.Tests/Common/SubtreeeXPathNavigatorTests/Tests.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests.SubtreeeXPathNavigatorTests;

--- a/src/Mvp.Xml.Tests/Common/UpperLowerTests/FirstUpperLowerTests.cs
+++ b/src/Mvp.Xml.Tests/Common/UpperLowerTests/FirstUpperLowerTests.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.UpperLowerTests;

--- a/src/Mvp.Xml.Tests/Common/XPathCacheTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XPathCacheTests.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/XPathCacheUsability.cs
+++ b/src/Mvp.Xml.Tests/Common/XPathCacheUsability.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Xml;
 using System.Xml.XPath;
-
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.Tests;
 

--- a/src/Mvp.Xml.Tests/Common/XPathDocumentWriterFixture.cs
+++ b/src/Mvp.Xml.Tests/Common/XPathDocumentWriterFixture.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests.Common;

--- a/src/Mvp.Xml.Tests/Common/XPathIteratorReaderTests/Tests.cs
+++ b/src/Mvp.Xml.Tests/Common/XPathIteratorReaderTests/Tests.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 using Xunit;
 
 namespace Mvp.Xml.Tests.XPathIteratorReaderTests;

--- a/src/Mvp.Xml.Tests/Common/XhtmlWriterTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XhtmlWriterTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Xml;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.Common;

--- a/src/Mvp.Xml.Tests/Common/XmlBaseAwareXmlReaderTests/Tests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlBaseAwareXmlReaderTests/Tests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.XmlBaseAwareXmlReaderTests;

--- a/src/Mvp.Xml.Tests/Common/XmlFragmentReaderTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlFragmentReaderTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Xml;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.Common;

--- a/src/Mvp.Xml.Tests/Common/XmlFragments/Tests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlFragments/Tests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Xml;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.XmlFragments;

--- a/src/Mvp.Xml.Tests/Common/XmlNodeFactoryTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlNodeFactoryTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.XPath;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/XmlNodeListFactoryTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlNodeListFactoryTests.cs
@@ -1,5 +1,4 @@
 using System.Xml;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml.Tests/Common/XmlNormalizingReaderFixture.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlNormalizingReaderFixture.cs
@@ -1,4 +1,3 @@
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests.Common;

--- a/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/StringSorterHelperTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/StringSorterHelperTests.cs
@@ -1,4 +1,3 @@
-using Mvp.Xml.Common.Serialization;
 using Xunit;
 
 namespace Mvp.Xml.Serialization.Tests;

--- a/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/ThumbprintHelpers.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/ThumbprintHelpers.cs
@@ -1,5 +1,4 @@
 using System.Xml.Serialization;
-using Mvp.Xml.Common.Serialization;
 using Xunit;
 
 namespace Mvp.Xml.Serialization.Tests;

--- a/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/XmlSerializerCacheTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlSerializerCacheTests/XmlSerializerCacheTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Xml.Serialization;
-using Mvp.Xml.Common.Serialization;
 using Xunit;
 
 namespace Mvp.Xml.Serialization.Tests;

--- a/src/Mvp.Xml.Tests/Common/XmlWrappingTests.cs
+++ b/src/Mvp.Xml.Tests/Common/XmlWrappingTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Xml;
 using System.Xml.Xsl;
-using Mvp.Xml.Common;
 using Xunit;
 
 namespace Mvp.Xml.Tests;

--- a/src/Mvp.Xml/Common/Guard.cs
+++ b/src/Mvp.Xml/Common/Guard.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Helper class with guard checks.

--- a/src/Mvp.Xml/Common/QName.cs
+++ b/src/Mvp.Xml/Common/QName.cs
@@ -1,4 +1,4 @@
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// XML Qualified Name (<a href="http://www.w3.org/TR/REC-xml-names/#dt-qualname">http://www.w3.org/TR/REC-xml-names/#dt-qualname</a>).

--- a/src/Mvp.Xml/Common/Serialization/CacheKeyFactory.cs
+++ b/src/Mvp.Xml/Common/Serialization/CacheKeyFactory.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Xml.Serialization;
 
-namespace Mvp.Xml.Common.Serialization;
+namespace Mvp.Xml.Serialization;
 
 /// <summary>
 /// The CacheKeyFactory extracts a unique signature

--- a/src/Mvp.Xml/Common/Serialization/SignatureExtractor.cs
+++ b/src/Mvp.Xml/Common/Serialization/SignatureExtractor.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Xml.Serialization;
 
-namespace Mvp.Xml.Common.Serialization;
+namespace Mvp.Xml.Serialization;
 
 // TODO:
 // I could test if the creating the hashvalue for the

--- a/src/Mvp.Xml/Common/Serialization/StringSorter.cs
+++ b/src/Mvp.Xml/Common/Serialization/StringSorter.cs
@@ -1,30 +1,29 @@
 ﻿using System.Collections.Generic;
 
-namespace Mvp.Xml.Common.Serialization
+namespace Mvp.Xml.Serialization;
+
+/// <summary>
+/// Helper class to simpify sorting
+/// strings (Not really necessary in Whidbey).
+/// </summary>
+public class StringSorter
 {
+    readonly List<string> list = new();
+
     /// <summary>
-    /// Helper class to simpify sorting
-    /// strings (Not really necessary in Whidbey).
+    /// Add a string to sort
     /// </summary>
-    public class StringSorter
+    /// <param name="s"></param>
+    public void AddString(string s) => list.Add(s);
+
+    /// <summary>
+    /// Sort the strings that were added by calling
+    /// <see cref="AddString"/>
+    /// </summary>
+    /// <returns>A sorted string array.</returns>
+    public string[] GetOrderedArray()
     {
-        readonly List<string> list = new();
-
-        /// <summary>
-        /// Add a string to sort
-        /// </summary>
-        /// <param name="s"></param>
-        public void AddString(string s) => list.Add(s);
-
-        /// <summary>
-        /// Sort the strings that were added by calling
-        /// <see cref="AddString"/>
-        /// </summary>
-        /// <returns>A sorted string array.</returns>
-        public string[] GetOrderedArray()
-        {
-            list.Sort();
-            return list.ToArray();
-        }
+        list.Sort();
+        return list.ToArray();
     }
 }

--- a/src/Mvp.Xml/Common/Serialization/XmlAttributeOverridesThumbprinter.cs
+++ b/src/Mvp.Xml/Common/Serialization/XmlAttributeOverridesThumbprinter.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace Mvp.Xml.Common.Serialization;
+namespace Mvp.Xml.Serialization;
 
 /// <summary>
 /// Helpers to create a normalized thumbprint

--- a/src/Mvp.Xml/Common/Serialization/XmlSerializerCache.cs
+++ b/src/Mvp.Xml/Common/Serialization/XmlSerializerCache.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace Mvp.Xml.Common.Serialization;
+namespace Mvp.Xml.Serialization;
 
 /// <summary>
 /// Delegete type for events to raise from the

--- a/src/Mvp.Xml/Common/XPath/DynamicContext.cs
+++ b/src/Mvp.Xml/Common/XPath/DynamicContext.cs
@@ -4,7 +4,7 @@ using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Provides the evaluation context for fast execution and custom 

--- a/src/Mvp.Xml/Common/XPath/EmptyXPathNodeIterator.cs
+++ b/src/Mvp.Xml/Common/XPath/EmptyXPathNodeIterator.cs
@@ -1,6 +1,6 @@
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Empty <see cref="XPathNodeIterator"/>, used to represent empty

--- a/src/Mvp.Xml/Common/XPath/IHasXPathNavigator.cs
+++ b/src/Mvp.Xml/Common/XPath/IHasXPathNavigator.cs
@@ -1,6 +1,6 @@
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Enables a class to return an <see cref="XPathNavigator"/> from the current context or position.

--- a/src/Mvp.Xml/Common/XPath/IndexingXPathNavigator.cs
+++ b/src/Mvp.Xml/Common/XPath/IndexingXPathNavigator.cs
@@ -4,7 +4,7 @@ using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>	
 /// <see cref="IndexingXPathNavigator"/> enables lazy or eager indexing of any XML store

--- a/src/Mvp.Xml/Common/XPath/SingletonXPathNodeIterator.cs
+++ b/src/Mvp.Xml/Common/XPath/SingletonXPathNodeIterator.cs
@@ -1,6 +1,6 @@
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// <see cref="XPathNodeIterator"/> over a single node. Can be used to return a single

--- a/src/Mvp.Xml/Common/XPath/SubtreeeXPathNavigator.cs
+++ b/src/Mvp.Xml/Common/XPath/SubtreeeXPathNavigator.cs
@@ -1,7 +1,7 @@
 using System.Xml;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>	
 /// Allows to navigate a subtree of an <see cref="IXPathNavigable"/> source, 

--- a/src/Mvp.Xml/Common/XPath/XPathCache.cs
+++ b/src/Mvp.Xml/Common/XPath/XPathCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Xml;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Implements a cache of XPath queries, for faster execution.

--- a/src/Mvp.Xml/Common/XPath/XPathDocumentWriter.cs
+++ b/src/Mvp.Xml/Common/XPath/XPathDocumentWriter.cs
@@ -6,7 +6,7 @@ using System.Security.Permissions;
 using System.Xml;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// <see cref="XmlWriter"/> that can produce an 

--- a/src/Mvp.Xml/Common/XPath/XPathIteratorReader.cs
+++ b/src/Mvp.Xml/Common/XPath/XPathIteratorReader.cs
@@ -3,7 +3,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Provides an <see cref="XmlReader"/> over an 

--- a/src/Mvp.Xml/Common/XPath/XPathNavigatorIterator.cs
+++ b/src/Mvp.Xml/Common/XPath/XPathNavigatorIterator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// An <see cref="XPathNodeIterator"/> that allows 

--- a/src/Mvp.Xml/Common/XPath/XPathVariable.cs
+++ b/src/Mvp.Xml/Common/XPath/XPathVariable.cs
@@ -1,4 +1,4 @@
-namespace Mvp.Xml.Common.XPath;
+namespace Mvp.Xml.XPath;
 
 /// <summary>
 /// Represents a variable to use in dynamic XPath expression 

--- a/src/Mvp.Xml/Common/XhtmlWriter.cs
+++ b/src/Mvp.Xml/Common/XhtmlWriter.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// XHTML writer. Writes XML using the HTML compatibility guidelines defined in the XHTML 1.0 specification.

--- a/src/Mvp.Xml/Common/XmlBaseAwareXmlReader.cs
+++ b/src/Mvp.Xml/Common/XmlBaseAwareXmlReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Custom <see cref="XmlReader"/> supporting <a href="http://www.w3.org/TR/xmlbase/">XML Base</a>.

--- a/src/Mvp.Xml/Common/XmlFirstLowerWriter.cs
+++ b/src/Mvp.Xml/Common/XmlFirstLowerWriter.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Implements an <see cref="XmlWriter"/> that turns the 

--- a/src/Mvp.Xml/Common/XmlFirstUpperReader.cs
+++ b/src/Mvp.Xml/Common/XmlFirstUpperReader.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Implements an <see cref="XmlTextReader"/> that turns the 

--- a/src/Mvp.Xml/Common/XmlFragmentReader.cs
+++ b/src/Mvp.Xml/Common/XmlFragmentReader.cs
@@ -1,6 +1,6 @@
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Wraps an <see cref="XmlReader"/> which was created to read 

--- a/src/Mvp.Xml/Common/XmlFragmentStream.cs
+++ b/src/Mvp.Xml/Common/XmlFragmentStream.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Allows streams without a root element (i.e. multiple document 

--- a/src/Mvp.Xml/Common/XmlNamespaces.cs
+++ b/src/Mvp.Xml/Common/XmlNamespaces.cs
@@ -1,4 +1,4 @@
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Provides public constants for wellknown XML namespaces.

--- a/src/Mvp.Xml/Common/XmlNodeFactory.cs
+++ b/src/Mvp.Xml/Common/XmlNodeFactory.cs
@@ -3,7 +3,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Creates <see cref="XmlNode"/> wrapper instances 

--- a/src/Mvp.Xml/Common/XmlNodeListFactory.cs
+++ b/src/Mvp.Xml/Common/XmlNodeListFactory.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Xml;
 using System.Xml.XPath;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Constructs <see cref="XmlNodeList"/> instances from 

--- a/src/Mvp.Xml/Common/XmlNormalizingReader.cs
+++ b/src/Mvp.Xml/Common/XmlNormalizingReader.cs
@@ -1,6 +1,6 @@
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Reader that only exposes xmlns attribute declarations if they 

--- a/src/Mvp.Xml/Common/XmlPrefix.cs
+++ b/src/Mvp.Xml/Common/XmlPrefix.cs
@@ -1,6 +1,6 @@
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Represents a mapping between a prefix and a namespace.

--- a/src/Mvp.Xml/Common/XmlWrappingReader.cs
+++ b/src/Mvp.Xml/Common/XmlWrappingReader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Base <see cref="XmlReader"/> that can be use to create new readers by 

--- a/src/Mvp.Xml/Common/XmlWrappingWriter.cs
+++ b/src/Mvp.Xml/Common/XmlWrappingWriter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Xml;
 
-namespace Mvp.Xml.Common;
+namespace Mvp.Xml;
 
 /// <summary>
 /// Base <see cref="XmlWriter"/> that can be use to create new writers

--- a/src/Mvp.Xml/Exslt/ExsltMath.cs
+++ b/src/Mvp.Xml/Exslt/ExsltMath.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.Exslt;
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Mvp.Xml/Exslt/ExsltSets.cs
+++ b/src/Mvp.Xml/Exslt/ExsltSets.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.XPath;
+using Mvp.Xml.XPath;
 //using System.Web.UI;
 
-using Mvp.Xml.Common.XPath;
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 namespace Mvp.Xml.Exslt;

--- a/src/Mvp.Xml/Exslt/GDNSets.cs
+++ b/src/Mvp.Xml/Exslt/GDNSets.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Xml.XPath;
-//using System.Web.UI;
-
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.Exslt;
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Mvp.Xml/XPointer/ElementSchemaPointerPart.cs
+++ b/src/Mvp.Xml/XPointer/ElementSchemaPointerPart.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.XPointer;
 

--- a/src/Mvp.Xml/XPointer/ShorthandPointer.cs
+++ b/src/Mvp.Xml/XPointer/ShorthandPointer.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.XPointer;
 

--- a/src/Mvp.Xml/XPointer/XPath1SchemaPointerPart.cs
+++ b/src/Mvp.Xml/XPointer/XPath1SchemaPointerPart.cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.XPointer;
 

--- a/src/Mvp.Xml/XPointer/XPointerReader.cs
+++ b/src/Mvp.Xml/XPointer/XPointerReader.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.XPointer;
 

--- a/src/Mvp.Xml/XPointer/XPointerSchemaPointerPart.cs
+++ b/src/Mvp.Xml/XPointer/XPointerSchemaPointerPart.cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.Xml;
 using System.Xml.XPath;
-using Mvp.Xml.Common.XPath;
+using Mvp.Xml.XPath;
 
 namespace Mvp.Xml.XPointer
 {


### PR DESCRIPTION
No need for the additional Common everywhere.